### PR TITLE
Suspending connect and disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Here's a basic example that just logs the characteristics (using [the `print()` 
 ```kotlin
 fun BluetoothDevice.logGattServices(tag: String = "BleGattCoroutines") = launch(UI) {
     val deviceConnection = GattConnection(bluetoothDevice = this@logGattServices)
-    deviceConnection.connect().await() // Await is optional
+    deviceConnection.connect() // Suspends until connection is established
     val gattServices = deviceConnection.discoverServices() // Suspends until completed
     gattServices.forEach {
         it.characteristics.forEach {
@@ -79,7 +79,7 @@ fun BluetoothDevice.logGattServices(tag: String = "BleGattCoroutines") = launch(
         }
         Log.v(tag, it.print(printCharacteristics = true))
     }
-    deviceConnection.disconnect().await() // Disconnection is optional. Useful if you don't close and reconnect later.
+    deviceConnection.disconnect() // Disconnection is optional. Useful if you don't close and reconnect later.
     deviceConnection.close() // Close when no longer used it NOT optional 
 }
 ```

--- a/sample-common/src/main/java/com/beepiz/blegattcoroutines/sample/common/extensions/GattHelpers.kt
+++ b/sample-common/src/main/java/com/beepiz/blegattcoroutines/sample/common/extensions/GattHelpers.kt
@@ -26,7 +26,7 @@ suspend inline fun BluetoothDevice.useBasic(connectionTimeoutInMillis: Long = 50
     try {
         deviceConnection.logConnectionChanges()
         withTimeout(connectionTimeoutInMillis) {
-            deviceConnection.connect().await()
+            deviceConnection.connect()
         }
         Timber.i("Connected!")
         val services = deviceConnection.discoverServices()


### PR DESCRIPTION
This better follows the name of the function, and still allows to write a `connectAsync` and a `disconnectAsync` extension function that returns a `Deferred<Unit>` if really needed.