### PR TITLE
Add requestMtu method to GattConnection

### DIFF
--- a/core/src/main/java/com/beepiz/bluetooth/gattcoroutines/GattConnection.kt
+++ b/core/src/main/java/com/beepiz/bluetooth/gattcoroutines/GattConnection.kt
@@ -138,6 +138,8 @@ interface GattConnection {
     @RequiresApi(26)
     suspend fun readPhy(): Phy
 
+    suspend fun requestMtu(mtu: Int): Int
+
     /**
      * **You should totally use this channel and implement the appropriate behavior for a production
      * app.**

--- a/core/src/main/java/com/beepiz/bluetooth/gattcoroutines/GattConnectionImpl.kt
+++ b/core/src/main/java/com/beepiz/bluetooth/gattcoroutines/GattConnectionImpl.kt
@@ -197,6 +197,11 @@ internal class GattConnectionImpl(
         readPhy().let { true }
     }
 
+    @RequiresApi(21)
+    override suspend fun requestMtu(mtu: Int) = gattRequest(mtuChannel) {
+        requestMtu(mtu)
+    }
+
     private val callback = object : BluetoothGattCallback() {
         override fun onConnectionStateChange(gatt: BG, status: Int, newState: Int) {
             when (status) {


### PR DESCRIPTION
Fixes #16. I've tested this and it seems to work -- ended up being really easy to add since the requestMtu channel was already there (and previously unused?).

Let me know if there's anything else I should test, but it seems like this should be an easy merge. And then I can go back to using the mainline version of this library instead of my fork :)

Thanks for your work on this lib!