### PR TITLE
Fixes characterist data lost issue

### DIFF
--- a/core/src/androidMain/kotlin/com/beepiz/bluetooth/gattcoroutines/GattConnectionImpl.kt
+++ b/core/src/androidMain/kotlin/com/beepiz/bluetooth/gattcoroutines/GattConnectionImpl.kt
@@ -276,7 +276,7 @@ internal class GattConnectionImpl(
         }
 
         override fun onCharacteristicChanged(gatt: BG, characteristic: BGC) {
-            launch { characteristicChangedChannel.send(characteristic) }
+            runBlocking { characteristicChangedChannel.send(characteristic) }
         }
 
         override fun onDescriptorRead(gatt: BG, descriptor: BGD, status: Int) {


### PR DESCRIPTION
This PR refers to #60 and fixes the issue.

Also I would like to suggest the use of a buffered channel (`Channel.BUFFERED`) instead of just using the broadcast channel with size 1, to avoid data loss again.